### PR TITLE
FIX: Shadow fix when reporting state

### DIFF
--- a/fs/init.js
+++ b/fs/init.js
@@ -9,7 +9,7 @@ let state = {on: false};        // Device state - LED on/off status
 Shadow.addHandler(function(event, obj) {
   if (event === 'CONNECTED') {
     // Connected to shadow - report our current state.
-    Shadow.update(0, {reported: state});
+    Shadow.update(0, state);
   } else if (event === 'UPDATE_DELTA') {
     // Got delta. Iterate over the delta keys, handle those we know about.
     for (let key in obj) {
@@ -24,7 +24,7 @@ Shadow.addHandler(function(event, obj) {
       }
     }
     // Once we've done synchronising with the shadow, report our state.
-    Shadow.update(0, {reported: state});
+    Shadow.update(0, state);
   }
 });
 


### PR DESCRIPTION
The state object has to be passed AS IS, not wrapped on a `reported` object like it was on previous versions.

Source: https://github.com/mongoose-os-libs/shadow/blob/master/mjs_fs/api_shadow.js#L40